### PR TITLE
Add a control stack

### DIFF
--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -27,6 +27,8 @@ module Wasm.Exec.Eval
   , getByName
   , createHostFunc
   , createHostFuncEff
+  , elem
+  , invoke
   ) where
 
 import           Control.Exception

--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -287,229 +287,201 @@ checkTypes at ts xs = forM_ (partialZip ts xs) $ \case
  *   c : config
  -}
 
-type EvalCont f m r = Stack Value -> DList (f (AdminInstr f m)) -> CEvalT f m r
-
 -- Make sure that our use of ReaderT does not get in the way of
 -- eta-expansion. See
 -- https://twitter.com/nomeata/status/1192731874248077312
 etaReaderT :: ReaderT r m a -> ReaderT r m a
 etaReaderT = ReaderT . oneShot . runReaderT
 
-instr :: (Regioned f, {-Show1 f,-} PrimMonad m)
-      => Stack Value -> Region -> Instr f
-      -> EvalCont f m r
-      -> CEvalT f m r
-instr vs at e' k = etaReaderT $ case (unFix e', vs) of
-  (Unreachable, vs)              -> {-# SCC step_Unreachable #-}
-    k vs (Trapping "unreachable executed" @@ at :)
-  (Nop, vs)                      -> {-# SCC step_Nop #-}
-    k vs id
-  (Block ts es', vs)             -> {-# SCC step_Block #-}
-    k vs (Label (length ts) id (Code [] (map plain es')) @@ at :)
-  (Loop _ es', vs)               -> {-# SCC step_Loop #-}
-    k vs (Label 0 ((plain $ e' @@ at):) (Code [] (map plain es')) @@ at :)
-  (If ts _ es2, I32 0 : vs')     -> {-# SCC step_If1 #-}
-    k vs' (Plain (Fix (Block ts es2)) @@ at :)
-  (If ts es1 _, I32 _ : vs')     -> {-# SCC step_If2 #-}
-    k vs' (Plain (Fix (Block ts es1)) @@ at :)
-  (Br x, vs)                     -> {-# SCC step_Br #-}
-    k [] (Breaking (value x) vs @@ at :)
-  (BrIf _, I32 0 : vs')          -> {-# SCC step_BrIf1 #-}
-    k vs' id
-  (BrIf x, I32 _ : vs')          -> {-# SCC step_BrIf2 #-}
-    k vs' (Plain (Fix (Br x)) @@ at:)
-  (BrTable xs x, I32 i : vs')
-    | i < 0 || fromIntegral i >= length xs -> {-# SCC step_BrTable1 #-}
-      k vs' (Plain (Fix (Br x)) @@ at:)
-    | otherwise -> {-# SCC step_BrTable2 #-}
-      k vs' (Plain (Fix (Br (xs !! fromIntegral i))) @@ at:)
-  (Return, vs)                   -> {-# SCC step_Return #-}
-    k vs (Returning vs @@ at:)
-
-  (Call x, vs) -> {-# SCC step_Call #-} do
-    inst <- getFrameInst
-    -- traceM $ "Call " ++ show (value x)
-    f <- lift $ func inst x
-    k vs (Invoke f @@ at:)
-
-  (CallIndirect x, I32 i : vs) -> {-# SCC step_CallIndirect #-} do
-    inst <- getFrameInst
-    func <- lift $ funcElem inst (0 @@ at) i at
-    t <- lift $ type_ inst x
-    k vs $
-      if t /= Func.typeOf func
-      then (Trapping "indirect call type mismatch" @@ at:)
-      else (Invoke func @@ at:)
-
-  (Drop, _ : vs') -> {-# SCC step_Drop #-}
-    k vs' id
-
-  (Select, I32 0 : v2 : _ : vs') -> {-# SCC step_Select1 #-}
-    k (v2 : vs') id
-  (Select, I32 _ : _ : v1 : vs') -> {-# SCC step_Select2 #-}
-    k (v1 : vs') id
-
-  (GetLocal x, vs) -> {-# SCC step_GetLocal #-} do
-    frame <- view configFrame
-    mut <- lift $ local frame x
-    l <- readMutVar mut
-    k (l : vs) id
-
-  (SetLocal x, v : vs') -> {-# SCC step_SetLocal #-} do
-    frame <- view configFrame
-    mut <- lift $ local frame x
-    writeMutVar mut v
-    k vs' id
-
-  (TeeLocal x, v : vs') -> {-# SCC step_TeeLocal #-} do
-    frame <- view configFrame
-    mut <- lift $ local frame x
-    writeMutVar mut v
-    k (v : vs') id
-
-  (GetGlobal x, vs) -> {-# SCC step_GetGlobal #-} do
-    inst <- getFrameInst
-    g <- lift . lift . Global.load =<< lift (global inst x)
-    -- traceM $ "GetGlobal " ++ show (value x) ++ " = " ++ show g
-    k (g : vs) id
-
-  (SetGlobal x, v : vs') -> {-# SCC step_SetGlobal #-} do
-    inst <- getFrameInst
-    g <- lift $ global inst x
-    eres <- lift $ lift $ runExceptT $ Global.store g v
-    case eres of
-      Right () -> k vs' id
-      Left err -> throwError $ EvalCrashError at $ case err of
-        Global.GlobalNotMutable -> "write to immutable global"
-        Global.GlobalTypeError  -> "type mismatch at global write"
-
-  (Load op, I32 i : vs') -> {-# SCC step_Load #-} do
-    inst <- getFrameInst
-    mem <- lift $ memory inst (0 @@ at)
-    let addr = fromIntegral $ i64_extend_u_i32 (fromIntegral i)
-    let off = fromIntegral (op^.memoryOffset)
-    let ty = op^.memoryValueType
-    eres <- lift $ lift $ runExceptT $ case op^.memorySize of
-          Nothing        -> Memory.loadValue mem addr off ty
-          Just (sz, ext) -> Memory.loadPacked sz ext mem addr off ty
-    case eres of
-      Right v' -> k (v' : vs') id
-      Left exn -> k vs' (Trapping (memoryErrorString exn) @@ at:)
-
-  (Store op, v : I32 i : vs') -> {-# SCC step_Store #-} do
-    inst <- getFrameInst
-    mem <- lift $ memory inst (0 @@ at)
-    let addr = fromIntegral $ i64_extend_u_i32 (fromIntegral i)
-    let off = fromIntegral (op^.memoryOffset)
-    eres <- lift $ lift $ runExceptT $ case op^.memorySize of
-          Nothing -> Memory.storeValue mem addr off v
-          Just sz -> Memory.storePacked sz mem addr off v
-    case eres of
-      Right () -> k vs' id
-      Left exn -> k vs' (Trapping (memoryErrorString exn) @@ at :)
-
-  (MemorySize, vs) -> {-# SCC step_MemorySize #-} do
-    inst <- getFrameInst
-    mem  <- lift $ memory inst (0 @@ at)
-    sz   <- lift $ lift $ Memory.size mem
-    k (I32 sz : vs) id
-
-  (MemoryGrow, I32 delta : vs') -> {-# SCC step_MemoryGrow #-} do
-    inst    <- getFrameInst
-    mem     <- lift $ memory inst (0 @@ at)
-    oldSize <- lift $ lift $ Memory.size mem
-    eres    <- lift $ lift $ runExceptT $ Memory.grow mem delta
-    let result = case eres of
-            Left _   -> -1
-            Right () -> oldSize
-    k (I32 result : vs') id
-
-  (Const v, vs) -> {-# SCC step_Const #-}
-    k (value v : vs) id
-
-  (Test testop, v : vs') -> {-# SCC step_Test #-} do
-    let eres = case testop of
-          I32TestOp o -> testOp @Int32 intTestOp o v
-          I64TestOp o -> testOp @Int64 intTestOp o v
-    case eres of
-      Left err -> k vs' (Trapping (show err) @@ at :)
-      Right v' -> k (v' : vs') id
-
-  (Compare relop, v2 : v1 : vs') -> {-# SCC step_Compare #-} do
-    let eres = case relop of
-          I32CompareOp o -> compareOp @Int32 intRelOp o v1 v2
-          I64CompareOp o -> compareOp @Int64 intRelOp o v1 v2
-          F32CompareOp o -> compareOp @Float floatRelOp o v1 v2
-          F64CompareOp o -> compareOp @Double floatRelOp o v1 v2
-    case eres of
-      Left err -> k vs' (Trapping (show err) @@ at :)
-      Right v' -> k (v' : vs') id
-
-  (Unary unop, v : vs') -> {-# SCC step_Unary #-} do
-    let eres = case unop of
-          I32UnaryOp o -> unaryOp @Int32 intUnOp o v
-          I64UnaryOp o -> unaryOp @Int64 intUnOp o v
-          F32UnaryOp o -> unaryOp @Float floatUnOp o v
-          F64UnaryOp o -> unaryOp @Double floatUnOp o v
-    case eres of
-      Left err -> k vs' (Trapping (show err) @@ at :)
-      Right v' -> k (v' : vs') id
-
-  (Binary binop, v2 : v1 : vs') -> {-# SCC step_Binary #-} do
-    let eres = case binop of
-          I32BinaryOp o -> binaryOp @Int32 intBinOp o v1 v2
-          I64BinaryOp o -> binaryOp @Int64 intBinOp o v1 v2
-          F32BinaryOp o -> binaryOp @Float floatBinOp o v1 v2
-          F64BinaryOp o -> binaryOp @Double floatBinOp o v1 v2
-    case eres of
-      Left err -> k vs' (Trapping (show err) @@ at :)
-      Right v' -> k (v' : vs') id
-
-  (Convert cvtop, v : vs') -> {-# SCC step_Convert #-} do
-    let eres = case cvtop of
-          I32ConvertOp o -> intCvtOp @Int32 o v
-          I64ConvertOp o -> intCvtOp @Int64 o v
-          F32ConvertOp o -> floatCvtOp @Float o v
-          F64ConvertOp o -> floatCvtOp @Double o v
-    case eres of
-      Left err -> k vs' (Trapping (show err) @@ at :)
-      Right v' -> k (v' : vs') id
-
-  _ ->  {-# SCC step_fallthrough_ #-} do
-    let s1 = show (reverse vs)
-        s2 = show (map Values.typeOf (reverse vs))
-    throwError $ EvalCrashError at
-      ("missing or ill-typed operand on stack (" ++ s1 ++ " : " ++ s2 ++ ")")
-
-{-# SPECIALIZE instr
-      :: Stack Value -> Region -> Instr Identity
-      -> (EvalCont Identity IO r)
-      -> CEvalT Identity IO r #-}
-
-{-# SPECIALIZE instr
-      :: Stack Value -> Region -> Instr Identity
-      -> (EvalCont Identity (ST s) r)
-      -> CEvalT Identity (ST s) r #-}
-
-{-# SPECIALIZE instr
-      :: Stack Value -> Region -> Instr Phrase
-      -> (EvalCont Phrase IO r)
-      -> CEvalT Phrase IO r #-}
-
-{-# SPECIALIZE instr
-      :: Stack Value -> Region -> Instr Phrase
-      -> (EvalCont Phrase (ST s) r)
-      -> CEvalT Phrase (ST s) r #-}
-
 step :: (Regioned f, PrimMonad m, Show1 f)
-     => Code f m -> (Code f m -> CEvalT f m r) -> CEvalT f m r
-step c k' = etaReaderT $ case c of
+     => Code f m -> CEvalT f m (Code f m)
+step c = etaReaderT $ case c of
   Code _ [] -> error "Cannot step without instructions"
   Code vs (e:es) ->
     let at = region e
-        k vs es' = k' (Code vs (es' es))
+        k vs es = return $ Code vs es
     in case value e of
-      Plain e' -> {-# SCC step_Plain #-} instr vs at e' k
+      Plain e' -> {-# SCC step_Plain #-} case (unFix e', vs) of
+        (Unreachable, vs)              -> {-# SCC step_Unreachable #-}
+          k vs (Trapping "unreachable executed" @@ at : es)
+        (Nop, vs)                      -> {-# SCC step_Nop #-}
+          k vs es
+        (Block ts es', vs)             -> {-# SCC step_Block #-}
+          k vs (Label (length ts) id (Code [] (map plain es')) @@ at : es)
+        (Loop _ es', vs)               -> {-# SCC step_Loop #-}
+          k vs (Label 0 ((plain $ e' @@ at):) (Code [] (map plain es')) @@ at : es)
+        (If ts _ es2, I32 0 : vs')     -> {-# SCC step_If1 #-}
+          k vs' (Plain (Fix (Block ts es2)) @@ at : es)
+        (If ts es1 _, I32 _ : vs')     -> {-# SCC step_If2 #-}
+          k vs' (Plain (Fix (Block ts es1)) @@ at : es)
+        (Br x, vs)                     -> {-# SCC step_Br #-}
+          k [] (Breaking (value x) vs @@ at : es)
+        (BrIf _, I32 0 : vs')          -> {-# SCC step_BrIf1 #-}
+          k vs' es
+        (BrIf x, I32 _ : vs')          -> {-# SCC step_BrIf2 #-}
+          k vs' (Plain (Fix (Br x)) @@ at : es)
+        (BrTable xs x, I32 i : vs')
+          | i < 0 || fromIntegral i >= length xs -> {-# SCC step_BrTable1 #-}
+            k vs' (Plain (Fix (Br x)) @@ at : es)
+          | otherwise -> {-# SCC step_BrTable2 #-}
+            k vs' (Plain (Fix (Br (xs !! fromIntegral i))) @@ at : es)
+        (Return, vs)                   -> {-# SCC step_Return #-}
+          k vs (Returning vs @@ at : es)
+
+        (Call x, vs) -> {-# SCC step_Call #-} do
+          inst <- getFrameInst
+          -- traceM $ "Call " ++ show (value x)
+          f <- lift $ func inst x
+          k vs (Invoke f @@ at : es)
+
+        (CallIndirect x, I32 i : vs) -> {-# SCC step_CallIndirect #-} do
+          inst <- getFrameInst
+          func <- lift $ funcElem inst (0 @@ at) i at
+          t <- lift $ type_ inst x
+          k vs $
+            if t /= Func.typeOf func
+            then Trapping "indirect call type mismatch" @@ at : es
+            else Invoke func @@ at :  es
+
+        (Drop, _ : vs') -> {-# SCC step_Drop #-}
+          k vs' es
+
+        (Select, I32 0 : v2 : _ : vs') -> {-# SCC step_Select1 #-}
+          k (v2 : vs') es
+        (Select, I32 _ : _ : v1 : vs') -> {-# SCC step_Select2 #-}
+          k (v1 : vs') es
+
+        (GetLocal x, vs) -> {-# SCC step_GetLocal #-} do
+          frame <- view configFrame
+          mut <- lift $ local frame x
+          l <- readMutVar mut
+          k (l : vs) es
+
+        (SetLocal x, v : vs') -> {-# SCC step_SetLocal #-} do
+          frame <- view configFrame
+          mut <- lift $ local frame x
+          writeMutVar mut v
+          k vs' es
+
+        (TeeLocal x, v : vs') -> {-# SCC step_TeeLocal #-} do
+          frame <- view configFrame
+          mut <- lift $ local frame x
+          writeMutVar mut v
+          k (v : vs') es
+
+        (GetGlobal x, vs) -> {-# SCC step_GetGlobal #-} do
+          inst <- getFrameInst
+          g <- lift . lift . Global.load =<< lift (global inst x)
+          -- traceM $ "GetGlobal " ++ show (value x) ++ " = " ++ show g
+          k (g : vs) es
+
+        (SetGlobal x, v : vs') -> {-# SCC step_SetGlobal #-} do
+          inst <- getFrameInst
+          g <- lift $ global inst x
+          eres <- lift $ lift $ runExceptT $ Global.store g v
+          case eres of
+            Right () -> k vs' es
+            Left err -> throwError $ EvalCrashError at $ case err of
+              Global.GlobalNotMutable -> "write to immutable global"
+              Global.GlobalTypeError  -> "type mismatch at global write"
+
+        (Load op, I32 i : vs') -> {-# SCC step_Load #-} do
+          inst <- getFrameInst
+          mem <- lift $ memory inst (0 @@ at)
+          let addr = fromIntegral $ i64_extend_u_i32 (fromIntegral i)
+          let off = fromIntegral (op^.memoryOffset)
+          let ty = op^.memoryValueType
+          eres <- lift $ lift $ runExceptT $ case op^.memorySize of
+                Nothing        -> Memory.loadValue mem addr off ty
+                Just (sz, ext) -> Memory.loadPacked sz ext mem addr off ty
+          case eres of
+            Right v' -> k (v' : vs') es
+            Left exn -> k vs' (Trapping (memoryErrorString exn) @@ at : es)
+
+        (Store op, v : I32 i : vs') -> {-# SCC step_Store #-} do
+          inst <- getFrameInst
+          mem <- lift $ memory inst (0 @@ at)
+          let addr = fromIntegral $ i64_extend_u_i32 (fromIntegral i)
+          let off = fromIntegral (op^.memoryOffset)
+          eres <- lift $ lift $ runExceptT $ case op^.memorySize of
+                Nothing -> Memory.storeValue mem addr off v
+                Just sz -> Memory.storePacked sz mem addr off v
+          case eres of
+            Right () -> k vs' es
+            Left exn -> k vs' (Trapping (memoryErrorString exn) @@ at : es)
+
+        (MemorySize, vs) -> {-# SCC step_MemorySize #-} do
+          inst <- getFrameInst
+          mem  <- lift $ memory inst (0 @@ at)
+          sz   <- lift $ lift $ Memory.size mem
+          k (I32 sz : vs) es
+
+        (MemoryGrow, I32 delta : vs') -> {-# SCC step_MemoryGrow #-} do
+          inst    <- getFrameInst
+          mem     <- lift $ memory inst (0 @@ at)
+          oldSize <- lift $ lift $ Memory.size mem
+          eres    <- lift $ lift $ runExceptT $ Memory.grow mem delta
+          let result = case eres of
+                  Left _   -> -1
+                  Right () -> oldSize
+          k (I32 result : vs') es
+
+        (Const v, vs) -> {-# SCC step_Const #-}
+          k (value v : vs) es
+
+        (Test testop, v : vs') -> {-# SCC step_Test #-} do
+          let eres = case testop of
+                I32TestOp o -> testOp @Int32 intTestOp o v
+                I64TestOp o -> testOp @Int64 intTestOp o v
+          case eres of
+            Left err -> k vs' (Trapping (show err) @@ at : es)
+            Right v' -> k (v' : vs') es
+
+        (Compare relop, v2 : v1 : vs') -> {-# SCC step_Compare #-} do
+          let eres = case relop of
+                I32CompareOp o -> compareOp @Int32 intRelOp o v1 v2
+                I64CompareOp o -> compareOp @Int64 intRelOp o v1 v2
+                F32CompareOp o -> compareOp @Float floatRelOp o v1 v2
+                F64CompareOp o -> compareOp @Double floatRelOp o v1 v2
+          case eres of
+            Left err -> k vs' (Trapping (show err) @@ at : es)
+            Right v' -> k (v' : vs') es
+
+        (Unary unop, v : vs') -> {-# SCC step_Unary #-} do
+          let eres = case unop of
+                I32UnaryOp o -> unaryOp @Int32 intUnOp o v
+                I64UnaryOp o -> unaryOp @Int64 intUnOp o v
+                F32UnaryOp o -> unaryOp @Float floatUnOp o v
+                F64UnaryOp o -> unaryOp @Double floatUnOp o v
+          case eres of
+            Left err -> k vs' (Trapping (show err) @@ at : es)
+            Right v' -> k (v' : vs') es
+
+        (Binary binop, v2 : v1 : vs') -> {-# SCC step_Binary #-} do
+          let eres = case binop of
+                I32BinaryOp o -> binaryOp @Int32 intBinOp o v1 v2
+                I64BinaryOp o -> binaryOp @Int64 intBinOp o v1 v2
+                F32BinaryOp o -> binaryOp @Float floatBinOp o v1 v2
+                F64BinaryOp o -> binaryOp @Double floatBinOp o v1 v2
+          case eres of
+            Left err -> k vs' (Trapping (show err) @@ at : es)
+            Right v' -> k (v' : vs') es
+
+        (Convert cvtop, v : vs') -> {-# SCC step_Convert #-} do
+          let eres = case cvtop of
+                I32ConvertOp o -> intCvtOp @Int32 o v
+                I64ConvertOp o -> intCvtOp @Int64 o v
+                F32ConvertOp o -> floatCvtOp @Float o v
+                F64ConvertOp o -> floatCvtOp @Double o v
+          case eres of
+            Left err -> k vs' (Trapping (show err) @@ at : es)
+            Right v' -> k (v' : vs') es
+
+        _ ->  {-# SCC step_fallthrough_ #-} do
+          let s1 = show (reverse vs)
+              s2 = show (map Values.typeOf (reverse vs))
+          throwError $ EvalCrashError at
+            ("missing or ill-typed operand on stack (" ++ s1 ++ " : " ++ s2 ++ ")")
 
       Trapping msg -> {-# SCC step_Trapping #-}
         throwError $ EvalTrapError at msg
@@ -519,34 +491,33 @@ step c k' = etaReaderT $ case c of
         throwError $ EvalCrashError at "undefined label"
 
       Label _ _ (Code vs' []) -> {-# SCC step_Label1 #-}
-        k (vs' ++ vs) id
+        k (vs' ++ vs) es
       Label n es0 code'@(Code _ (t@(value -> c) : _)) -> {-# SCC step_Label2 #-}
         case c of
           Trapping msg -> {-# SCC step_Label3 #-}
-            k vs (Trapping msg @@ region t:)
+            k vs (Trapping msg @@ region t : es)
           Returning vs0 -> {-# SCC step_Label4 #-}
-            k vs (Returning vs0 @@ region t:)
+            k vs (Returning vs0 @@ region t : es)
           Breaking 0 vs0 -> {-# SCC step_Label5 #-} do
             vs0' <- lift $ takeFrom n vs0 at
-            k (vs0' ++ vs) es0
+            k (vs0' ++ vs) (es0 es)
           Breaking bk vs0 -> {-# SCC step_Label6 #-}
-            k vs (Breaking (bk - 1) vs0 @@ at:)
+            k vs (Breaking (bk - 1) vs0 @@ at : es)
           _ -> {-# SCC step_Label7 #-} do
-            step code' $ \res -> {-# SCC step_Label7_k #-} do
-              k vs (Label n es0 res @@ at:)
+            res <- step code'
+            k vs (Label n es0 res @@ at : es)
 
       Framed _ _ (Code vs' []) -> {-# SCC step_Framed1 #-}
-        k (vs' ++ vs) id
+        k (vs' ++ vs) es
       Framed _ _ (Code _ (t@(value -> Trapping msg) : _)) -> {-# SCC step_Framed2 #-}
-        k vs (Trapping msg @@ region t:)
+        k vs (Trapping msg @@ region t : es)
       Framed n _ (Code _ ((value -> Returning vs0) : _)) -> {-# SCC step_Framed3 #-} do
         vs0' <- lift $ takeFrom n vs0 at
-        k (vs0' ++ vs) id
+        k (vs0' ++ vs) es
       Framed n frame' code' -> {-# SCC step_Framed4 #-}
-        Reader.local (\c -> c & configFrame .~ frame'
-                             & configBudget %~ pred) $
-          step code' $ \res ->
-            k vs (Framed n frame' res @@ at:)
+        Reader.local (\c -> c & configFrame .~ frame' & configBudget %~ pred) $ do
+          res <- step code'
+          k vs (Framed n frame' res @@ at : es)
 
       Invoke func -> {-# SCC step_Invoke #-} do
         budget <- view configBudget
@@ -575,14 +546,14 @@ step c k' = etaReaderT $ case c of
               args ++ map defaultValue (value f^.funcLocals)
             let code' = Code [] [Plain (Fix (Block outs (value f^.funcBody))) @@ region f]
                 frame' = Frame inst' locals'
-            k vs' (Framed (length outs) frame' code' @@ at:)
+            k vs' (Framed (length outs) frame' code' @@ at : es)
 
           Func.HostFunc _ f -> do
             -- jww (2018-11-01): Need an exception handler here, so we can
             -- report host errors.
             let res = reverse (f args)
             lift $ checkTypes at outs res
-            k (res ++ vs') id
+            k (res ++ vs') es
             -- try (reverse (f args) ++ vs', [])
             -- with Crash (_, msg) -> EvalCrashError at msg)
 
@@ -594,25 +565,14 @@ step c k' = etaReaderT $ case c of
               Left err -> throwError $ EvalTrapError at err
               Right (reverse -> res) -> do
                 lift $ checkTypes at outs res
-                k (res ++ vs') id
+                k (res ++ vs') es
                 -- try (reverse (f args) ++ vs', [])
                 -- with Crash (_, msg) -> EvalCrashError at msg)
 
-{-# SPECIALIZE step
-      :: Code Identity IO -> (Code Identity IO -> CEvalT Identity IO r)
-      -> CEvalT Identity IO r #-}
-
-{-# SPECIALIZE step
-      :: Code Identity (ST s) -> (Code Identity (ST s) -> CEvalT Identity (ST s) r)
-      -> CEvalT Identity (ST s) r #-}
-
-{-# SPECIALIZE step
-      :: Code Phrase IO -> (Code Phrase IO -> CEvalT Phrase IO r)
-      -> CEvalT Phrase IO r #-}
-
-{-# SPECIALIZE step
-      :: Code Phrase (ST s) -> (Code Phrase (ST s) -> CEvalT Phrase (ST s) r)
-      -> CEvalT Phrase (ST s) r #-}
+{-# SPECIALIZE step :: Code Identity IO -> CEvalT Identity IO (Code Identity IO) #-}
+{-# SPECIALIZE step :: Code Identity (ST s) -> CEvalT Identity (ST s) (Code Identity (ST s)) #-}
+{-# SPECIALIZE step :: Code Phrase IO -> CEvalT Phrase IO (Code Phrase IO) #-}
+{-# SPECIALIZE step :: Code Phrase (ST s) -> CEvalT Phrase (ST s) (Code Phrase (ST s)) #-}
 
 eval :: (Regioned f, PrimMonad m, Show1 f)
      => Code f m -> CEvalT f m (Stack Value)
@@ -620,19 +580,12 @@ eval c@(Code vs es) = etaReaderT $ case es of
   [] -> pure vs
   t@(value -> Trapping msg) : _ ->
     throwError $ EvalTrapError (region t) msg
-  _ -> step c eval
+  _ -> step c >>= eval
 
-{-# SPECIALIZE eval
-      :: Code Identity IO -> CEvalT Identity IO (Stack Value) #-}
-
-{-# SPECIALIZE eval
-      :: Code Identity (ST s) -> CEvalT Identity (ST s) (Stack Value) #-}
-
-{-# SPECIALIZE eval
-      :: Code Phrase IO -> CEvalT Phrase IO (Stack Value) #-}
-
-{-# SPECIALIZE eval
-      :: Code Phrase (ST s) -> CEvalT Phrase (ST s) (Stack Value) #-}
+{-# SPECIALIZE eval :: Code Identity IO -> CEvalT Identity IO (Stack Value) #-}
+{-# SPECIALIZE eval :: Code Identity (ST s) -> CEvalT Identity (ST s) (Stack Value) #-}
+{-# SPECIALIZE eval :: Code Phrase IO -> CEvalT Phrase IO (Stack Value) #-}
+{-# SPECIALIZE eval :: Code Phrase (ST s) -> CEvalT Phrase (ST s) (Stack Value) #-}
 
 {- Functions & Constants -}
 

--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -128,6 +128,15 @@ In a change from the reference interpreter, where the small-step relation works
 on just a value and instruction set, we introduce a control stack as well. This
 gives a significant performance boost.
 
+The correspondence between their and our 'Code' type is the following:
+
+    Wasm:   (vs1, Label n les (vs2, es2) :: es1)
+    Winter: Code cfg1 (Label n les les (Code … cfg2 vs1 es1)) vs2 es2
+
+The point is that now es2 (the instruction to execute next) is nicely exposed
+for O(1) analsys, instead of hidden deep in the Code data structure. On
+can also think of this as a zipper.
+
 We also keep track of the current 'Config' (esp 'configFrame') here.
 -}
 

--- a/src/Wasm/Runtime/Memory.hs
+++ b/src/Wasm/Runtime/Memory.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Wasm.Runtime.Memory
-  ( MemoryInst
+  ( MemoryInst(..)
   , doubleFromBits, doubleToBits
   , floatFromBits, floatToBits
   , typeOf

--- a/src/Wasm/Util/Source.hs
+++ b/src/Wasm/Util/Source.hs
@@ -19,7 +19,7 @@ import           GHC.Generics
 import           Lens.Micro.Platform
 import           Text.Printf
 
-infixl 5 @@
+infixl 6 @@
 
 class Traversable phrase => Regioned phrase where
   region :: phrase a -> Region


### PR DESCRIPTION
instead of evaluating within an instruction (expensive!), put them on a stack.

90% less allocation! 62% less execution time!

Unfortunately distances the code a bit from the reference implementation. There is still a (mostly) clear mapping from this `Code` type to the old one, so hopefully it is not too bad.