### PR TITLE
Use ByteArray internal

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { compiler ? "ghc864"
 
-, rev    ? "e0c7712eac67c6b820d9d1020f46bac96fd8cede"
-, sha256 ? "08rcnqxkninl5a560ss39s4nbqf0a677q6qh1fh7i0lr9pxf6aan"
+, rev    ? "105e5282b20dc89c209604166a2731ecb43d9bb7"
+, sha256 ? "0vcrgjsm8snrjx1nwdz71ww0y1732fb45xnsjmxpq9504gzv6sxv"
 
 , pkgs   ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0

--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -45,6 +45,7 @@ import           Data.Functor.Classes
 import           Data.Int
 import           Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
+import           Data.Primitive.ByteArray (byteArrayFromListN)
 import           Data.Primitive.MutVar
 import           Data.List hiding (lookup, elem)
 import           Data.Map (Map)
@@ -811,8 +812,11 @@ initMemory mods inst s@(value -> seg) = do
   when (fromIntegral bound < end_ || end_ < fromIntegral offset) $
     throwError $ EvalLinkError (region s) "data segment does not fit memory"
   liftMem (region s) $
-    Memory.storeBytes mem (fromIntegral offset)
-                      (V.fromList (B.unpack (seg^.segmentInit)))
+    Memory.storeBytes mem (fromIntegral offset) $
+        -- No good way of converting ByteString to ByteArray known
+        byteArrayFromListN
+            (fromIntegral (B.length (seg^.segmentInit)))
+            (B.unpack (seg^.segmentInit))
 
 addImport :: (Regioned f, PrimMonad m)
           => ModuleInst f m

--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -45,7 +45,6 @@ import           Data.Functor.Classes
 import           Data.Int
 import           Data.IntMap (IntMap)
 import qualified Data.IntMap as IM
-import           Data.Primitive.ByteArray (byteArrayFromListN)
 import           Data.Primitive.MutVar
 import           Data.List hiding (lookup, elem)
 import           Data.Map (Map)
@@ -812,11 +811,7 @@ initMemory mods inst s@(value -> seg) = do
   when (fromIntegral bound < end_ || end_ < fromIntegral offset) $
     throwError $ EvalLinkError (region s) "data segment does not fit memory"
   liftMem (region s) $
-    Memory.storeBytes mem (fromIntegral offset) $
-        -- No good way of converting ByteString to ByteArray known
-        byteArrayFromListN
-            (fromIntegral (B.length (seg^.segmentInit)))
-            (B.unpack (seg^.segmentInit))
+    Memory.storeBytes mem (fromIntegral offset) (B.toStrict (seg^.segmentInit))
 
 addImport :: (Regioned f, PrimMonad m)
           => ModuleInst f m

--- a/src/Wasm/Exec/Eval.hs
+++ b/src/Wasm/Exec/Eval.hs
@@ -811,7 +811,7 @@ initMemory mods inst s@(value -> seg) = do
   when (fromIntegral bound < end_ || end_ < fromIntegral offset) $
     throwError $ EvalLinkError (region s) "data segment does not fit memory"
   liftMem (region s) $
-    Memory.storeBytes mem (fromIntegral offset) (B.toStrict (seg^.segmentInit))
+    Memory.storeBytes mem (fromIntegral offset) (seg^.segmentInit)
 
 addImport :: (Regioned f, PrimMonad m)
           => ModuleInst f m

--- a/src/Wasm/Runtime/Memory.hs
+++ b/src/Wasm/Runtime/Memory.hs
@@ -32,7 +32,8 @@ import           Data.Array.Unsafe (castSTUArray)
 import           Data.Int
 import           Data.Primitive.MutVar
 import           Data.Primitive.ByteArray
-import           Data.Primitive.ByteArray.Unaligned
+import qualified Data.Primitive.ByteArray.Unaligned    as UABA
+import qualified Data.Primitive.ByteArray.LittleEndian as LEBA
 import           Data.Vector (Vector)
 import qualified Data.Vector as V
 import           Data.Word
@@ -174,10 +175,10 @@ loadValue mem a o t = do
   lift $ do
     m <- readMutVar (mem^.miContent)
     case t of
-      I32Type -> Values.I32 <$> readUnalignedByteArray m (fromIntegral addr)
-      I64Type -> Values.I64 <$> readUnalignedByteArray m (fromIntegral addr)
-      F32Type -> Values.F32 <$> readUnalignedByteArray m (fromIntegral addr)
-      F64Type -> Values.F64 <$> readUnalignedByteArray m (fromIntegral addr)
+      I32Type -> Values.I32 <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+      I64Type -> Values.I64 <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+      F32Type -> Values.F32 <$> UABA.readUnalignedByteArray m (fromIntegral addr)
+      F64Type -> Values.F64 <$> UABA.readUnalignedByteArray m (fromIntegral addr)
 
 storeValue :: (PrimMonad m)
            => MemoryInst m -> Address -> Offset -> Value
@@ -190,10 +191,10 @@ storeValue mem a o v = do
   lift $ do
     m <- readMutVar (mem^.miContent)
     case v of
-      Values.I32 y -> writeUnalignedByteArray m (fromIntegral addr) y
-      Values.I64 y -> writeUnalignedByteArray m (fromIntegral addr) y
-      Values.F32 y -> writeUnalignedByteArray m (fromIntegral addr) y
-      Values.F64 y -> writeUnalignedByteArray m (fromIntegral addr) y
+      Values.I32 y -> LEBA.writeUnalignedByteArray m (fromIntegral addr) y
+      Values.I64 y -> LEBA.writeUnalignedByteArray m (fromIntegral addr) y
+      Values.F32 y -> UABA.writeUnalignedByteArray m (fromIntegral addr) y
+      Values.F64 y -> UABA.writeUnalignedByteArray m (fromIntegral addr) y
 
 -- Packed access
 
@@ -215,19 +216,19 @@ loadPacked sz ext mem a o t = do
     m <- lift $ readMutVar (mem^.miContent)
     case t of
       I32Type -> lift $ Values.I32 <$> case (ext, sz) of
-        (ZX, Pack8)  -> fromIntegral @Word8  <$> readUnalignedByteArray m (fromIntegral addr)
-        (SX, Pack8)  -> fromIntegral @Int8   <$> readUnalignedByteArray m (fromIntegral addr)
-        (ZX, Pack16) -> fromIntegral @Word16 <$> readUnalignedByteArray m (fromIntegral addr)
-        (SX, Pack16) -> fromIntegral @Int16  <$> readUnalignedByteArray m (fromIntegral addr)
-        (ZX, Pack32) -> fromIntegral @Word32 <$> readUnalignedByteArray m (fromIntegral addr)
-        (SX, Pack32) -> fromIntegral @Int32  <$> readUnalignedByteArray m (fromIntegral addr)
+        (ZX, Pack8)  -> fromIntegral @Word8  <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (SX, Pack8)  -> fromIntegral @Int8   <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (ZX, Pack16) -> fromIntegral @Word16 <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (SX, Pack16) -> fromIntegral @Int16  <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (ZX, Pack32) -> fromIntegral @Word32 <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (SX, Pack32) -> fromIntegral @Int32  <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
       I64Type -> lift $ Values.I64 <$> case (ext, sz) of
-        (ZX, Pack8)  -> fromIntegral @Word8  <$> readUnalignedByteArray m (fromIntegral addr)
-        (SX, Pack8)  -> fromIntegral @Int8   <$> readUnalignedByteArray m (fromIntegral addr)
-        (ZX, Pack16) -> fromIntegral @Word16 <$> readUnalignedByteArray m (fromIntegral addr)
-        (SX, Pack16) -> fromIntegral @Int16  <$> readUnalignedByteArray m (fromIntegral addr)
-        (ZX, Pack32) -> fromIntegral @Word32 <$> readUnalignedByteArray m (fromIntegral addr)
-        (SX, Pack32) -> fromIntegral @Int32  <$> readUnalignedByteArray m (fromIntegral addr)
+        (ZX, Pack8)  -> fromIntegral @Word8  <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (SX, Pack8)  -> fromIntegral @Int8   <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (ZX, Pack16) -> fromIntegral @Word16 <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (SX, Pack16) -> fromIntegral @Int16  <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (ZX, Pack32) -> fromIntegral @Word32 <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
+        (SX, Pack32) -> fromIntegral @Int32  <$> LEBA.readUnalignedByteArray m (fromIntegral addr)
       _ -> throwError MemoryTypeError
 
 storePacked :: PrimMonad m
@@ -243,13 +244,13 @@ storePacked sz mem a o v = do
     m <- lift $ readMutVar (mem^.miContent)
     case v of
       Values.I32 y -> lift $ case sz of
-        Pack8  -> writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word8 y)
-        Pack16 -> writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word16 y)
-        Pack32 -> writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word32 y)
+        Pack8  -> LEBA.writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word8 y)
+        Pack16 -> LEBA.writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word16 y)
+        Pack32 -> LEBA.writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word32 y)
       Values.I64 y -> lift $ case sz of
-        Pack8  -> writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word8 y)
-        Pack16 -> writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word16 y)
-        Pack32 -> writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word32 y)
+        Pack8  -> LEBA.writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word8 y)
+        Pack16 -> LEBA.writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word16 y)
+        Pack32 -> LEBA.writeUnalignedByteArray m (fromIntegral addr) (fromIntegral @_ @Word32 y)
       _ -> throwError MemoryTypeError
 
 -- Conversions used in "Wasm.Exec.EvalNumeric"

--- a/src/Wasm/Runtime/Memory.hs
+++ b/src/Wasm/Runtime/Memory.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Wasm.Runtime.Memory
-  ( MemoryInst
+  ( MemoryInst(..)
   , doubleFromBits, doubleToBits
   , floatFromBits, floatToBits
   , typeOf

--- a/winter.cabal
+++ b/winter.cabal
@@ -39,7 +39,8 @@ Library
     transformers,
     vector,
     primitive,
-    primitive-unaligned
+    primitive-unaligned,
+    byte-order
   Exposed-Modules:
     Wasm.Binary.Custom
     Wasm.Binary.Decode

--- a/winter.cabal
+++ b/winter.cabal
@@ -38,7 +38,8 @@ Library
     text,
     transformers,
     vector,
-    primitive
+    primitive,
+    primitive-unaligned
   Exposed-Modules:
     Wasm.Binary.Custom
     Wasm.Binary.Decode


### PR DESCRIPTION
from the `primitive` package. The main benefit of using this is efficient reads and writes for 32 and 64 bit words, which improves performance of a simple test case by like ⅓.

This choice stays internal. The `Memory` module now exports its interface in terms of lazy `ByteString`, not `Vector`, avoiding some copies.

It also adds `exportMemory` and `importMemory` functions, convenient for debugging of when trying to suspend a WebAssembly program.