### PR TITLE
Test against the v1.1 reference interpreter test suite

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,9 +24,8 @@ haskellPackages = pkgs.haskell.packages.${compiler};
 wasm-src = pkgs.fetchFromGitHub {
     owner  = "WebAssembly";
     repo   = "spec";
-    rev    = "a56cf2ec042da382f0196fe14dcbd7ff2e973466";
-    sha256 = "02c7bpmjmq3bxp4w0g8gkg87ixh4x67d9hz4g25i4snxnc7bj0g7";
-    # date = 2018-10-31T18:30:05+01:00;
+    rev    = "v1.1";
+    sha256 = "1jsgrjqzsdmm6f5pgd947nikj7pnxx1mqdnz16j7s62rg8x06h7d";
   };
 
 drv = haskellPackages.developPackage {

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -21,17 +21,19 @@ main = do
         [ testDir ++ "/" ++ file
         | ".wast" `isSuffixOf` file
             && "inline-module.wast" /= file
-              -- jww (2018-11-02): We aren't going to bother fully supporting
+              -- We aren't going to bother fully supporting
               -- Unicode function names in the reference interpreter yet.
             && "names.wast" /= file
-              -- jww (2018-11-03): We need more accurate floating-point support.
+              -- We need more accurate floating-point support.
+            && "f32.wast" /= file
+            && "f64.wast" /= file
             && "f32_bitwise.wast" /= file
             && "f64_bitwise.wast" /= file
             && "float_literals.wast" /= file
             && "float_exprs.wast" /= file
             && "conversions.wast" /= file
             && "address.wast" /= file
-              -- jww (2018-11-03): Strange behavior from shl
+              -- Strange behavior from shl
             && "i32.wast" /= file
             && "i64.wast" /= file
         ]


### PR DESCRIPTION
for the most part, this meant parsing some more `nan:` forms, ignoring
some more files and tests.

I added support for `(asset_trap (module …))`, this uncovers a problem
with how we linking modules that trap during `(start)`: these modules
actually can write functions to other module’s tables and these are then
usable, even if `(start)` traps. Pretty odd.